### PR TITLE
[wip] implementing data relationships with redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-mirage": "0.2.1",
+    "ember-cli-mirage": "0.2.2",
     "ember-cli-mocha": "0.10.4",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",

--- a/tests/acceptance/relationship-get-test.js
+++ b/tests/acceptance/relationship-get-test.js
@@ -1,0 +1,77 @@
+/* jshint expr:true */
+import {
+  describe,
+  it,
+  before,
+  after
+} from 'mocha';
+import { expect } from 'chai';
+import { getList } from 'ember-with-redux/utils/ds-collections';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+describe('Acceptance: RelationshipGet', function() {
+  let application, container, store, redux;
+
+  before(function(done) {
+    application = startApp();
+    server.create('shop', 'hasGuns');
+    server.create('shop');
+    visit('/');
+    andThen(() => {
+      container = application.__container__;
+      store = container.lookup('service:store');
+      redux = container.lookup('service:redux');
+      done();
+    });
+  });
+
+  after(function() {
+    destroyApp(application);
+  });
+
+  describe('finding shops', function() {
+    let shops, dsState;
+    before(function(done) {
+      store.findAll('shop').then(() => {
+        dsState = redux.getState().ds;
+        shops = getList(dsState, { modelName: 'shop' });
+        done();
+      });
+    });
+
+    it('should be a list', function() {
+      expect(shops).to.be.ok;
+      expect(shops).to.respondTo('push');
+      expect(shops).to.respondTo('pop');
+    });
+
+    it('should have the correct count', function() {
+      expect(shops.count()).to.equal(2);
+    });
+
+    describe('shop with guns', function() {
+      let shop;
+      before(function() {
+        shop = shops.first();
+      });
+      it('should have be the correct model', function() {
+        const meta = shop.get('meta');
+        expect(meta).to.have.property('modelName', 'shop');
+        expect(meta).to.have.property('id');
+      });
+      describe('relational data', function() {
+        let data;
+        before(function() {
+          data = shop.get('data');
+        });
+        it('should have sensible regular data', function() {
+          expect(data).to.have.property('name');
+        });
+        it('should have a relational reference', function() {
+          expect(data).to.have.property('guns');
+        });
+      });
+    });
+  });
+});

--- a/tests/dummy/app/models/gun.js
+++ b/tests/dummy/app/models/gun.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  brand: DS.attr('string'),
+  price: DS.attr('number'),
+  shop: DS.belongsTo('shop')
+});

--- a/tests/dummy/app/models/shop.js
+++ b/tests/dummy/app/models/shop.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  guns: DS.hasMany('gun')
+});

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -29,14 +29,7 @@ export default function() {
   this.get('/dogs/:id');
   this.get('/dogs');
   this.post('/dogs');
-  this.patch('/dogs/:id', function(db, request) {
-    const { dogs } = db;
-    const id = request.params.id;
-    const attrs = this.normalizedRequestAttrs();
-    const dog = dogs.find(id);
-    const updatedDog = dog.update('attrs', attrs);
-    return updatedDog;
-  });
+  this.patch('/dogs/:id');
   this.get('/shops');
   this.get('/guns');
 }

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -37,4 +37,6 @@ export default function() {
     const updatedDog = dog.update('attrs', attrs);
     return updatedDog;
   });
+  this.get('/shops');
+  this.get('/guns');
 }

--- a/tests/dummy/mirage/factories/gun.js
+++ b/tests/dummy/mirage/factories/gun.js
@@ -1,0 +1,10 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  brand() {
+    return faker.name.firstName();
+  },
+  price() {
+    return Math.random();
+  }
+});

--- a/tests/dummy/mirage/factories/shop.js
+++ b/tests/dummy/mirage/factories/shop.js
@@ -1,0 +1,13 @@
+import { Factory, trait, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  name() {
+    return faker.company.companyName();
+  },
+
+  hasGuns: trait({
+    afterCreate(shop, server) {
+      server.createList('gun', 5, { shop });
+    }
+  })
+});

--- a/tests/dummy/mirage/models/gun.js
+++ b/tests/dummy/mirage/models/gun.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  shop: belongsTo('shop')
+});

--- a/tests/dummy/mirage/models/shop.js
+++ b/tests/dummy/mirage/models/shop.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  guns: hasMany('gun')
+});


### PR DESCRIPTION
# Background

This PR will hopefully provide a sensible and pure way of accessing and modifying relational `hasMany` and `belongsTo` fields from ember-data
# Changes

So far:
- changed `dsModelToPOJO` to be relationship aware
- updated mirage to get access to traits
- added a relationship-get test to to TDD out how this would work
- added shops and guns to model a standard belongsTo-hasMany relationship
# References

https://github.com/foxnewsnetwork/ember-with-redux/issues/6
# ToDo
- [x] Fix `recordToModel` to use `hasMany` and `belongsTo` as appropriate
- [ ] Create some sort of `ds-ref` file that holds functions on working with relationship references in redux
- [ ] Implement ways to `append`, `remove`, and `transduce` elements in references the same way we currently do with regular queries
